### PR TITLE
Make Reducer generic over errors

### DIFF
--- a/Samples/AnimalsData/Sources/AnimalsData/AnimalsReducer.swift
+++ b/Samples/AnimalsData/Sources/AnimalsData/AnimalsReducer.swift
@@ -20,7 +20,7 @@ public enum AnimalsReducer {
   @Sendable public static func reduce(
     state: AnimalsState,
     action: AnimalsAction
-  ) throws -> AnimalsState {
+  ) throws(AnimalsReducer.Error) -> AnimalsState {
     switch action {
     case .ui(action: let action):
       return try self.reduce(state: state, action: action)
@@ -34,7 +34,7 @@ extension AnimalsReducer {
   private static func reduce(
     state: AnimalsState,
     action: AnimalsAction.UI
-  ) throws -> AnimalsState {
+  ) throws(AnimalsReducer.Error) -> AnimalsState {
     switch action {
     case .categoryList(action: let action):
       return try self.reduce(state: state, action: action)
@@ -52,7 +52,7 @@ extension AnimalsReducer {
   private static func reduce(
     state: AnimalsState,
     action: AnimalsAction.UI.CategoryList
-  ) throws -> AnimalsState {
+  ) throws(AnimalsReducer.Error) -> AnimalsState {
     switch action {
     case .onAppear:
       if state.categories.status == nil {
@@ -75,17 +75,17 @@ extension AnimalsReducer {
 }
 
 extension AnimalsReducer {
-  package struct Error: Swift.Error {
-    package enum Code: Hashable, Sendable {
+  public struct Error: Swift.Error {
+    public enum Code: Hashable, Sendable {
       case animalNotFound
     }
     
-    package let code: Self.Code
+    public let code: Self.Code
   }
 }
 
 extension AnimalsState {
-  fileprivate func onTapDeleteSelectedAnimalButton(animalId: Animal.ID) throws -> Self {
+  fileprivate func onTapDeleteSelectedAnimalButton(animalId: Animal.ID) throws(AnimalsReducer.Error) -> Self {
     guard let _ = self.animals.data[animalId] else {
       throw AnimalsReducer.Error(code: .animalNotFound)
     }
@@ -99,7 +99,7 @@ extension AnimalsReducer {
   private static func reduce(
     state: AnimalsState,
     action: AnimalsAction.UI.AnimalList
-  ) throws -> AnimalsState {
+  ) throws(AnimalsReducer.Error) -> AnimalsState {
     switch action {
     case .onAppear:
       if state.animals.status == nil {
@@ -118,7 +118,7 @@ extension AnimalsReducer {
   private static func reduce(
     state: AnimalsState,
     action: AnimalsAction.UI.AnimalDetail
-  ) throws -> AnimalsState {
+  ) throws(AnimalsReducer.Error) -> AnimalsState {
     switch action {
     case .onTapDeleteSelectedAnimalButton(animalId: let animalId):
       return try state.onTapDeleteSelectedAnimalButton(animalId: animalId)
@@ -145,7 +145,7 @@ extension AnimalsState {
     name: String,
     diet: Animal.Diet,
     categoryId: Category.ID
-  ) throws -> Self {
+  ) throws(AnimalsReducer.Error) -> Self {
     guard let _ = self.animals.data[animalId] else {
       throw AnimalsReducer.Error(code: .animalNotFound)
     }
@@ -159,7 +159,7 @@ extension AnimalsReducer {
   private static func reduce(
     state: AnimalsState,
     action: AnimalsAction.UI.AnimalEditor
-  ) throws -> AnimalsState {
+  ) throws(AnimalsReducer.Error) -> AnimalsState {
     switch action {
     case .onTapAddAnimalButton(id: let id, name: let name, diet: let diet, categoryId: let categoryId):
       return state.onTapAddAnimalButton(id: id, name: name, diet: diet, categoryId: categoryId)
@@ -173,7 +173,7 @@ extension AnimalsReducer {
   private static func reduce(
     state: AnimalsState,
     action: AnimalsAction.Data
-  ) throws -> AnimalsState {
+  ) throws(AnimalsReducer.Error) -> AnimalsState {
     switch action {
     case .persistentSession(.didFetchCategories(result: let result)):
       return self.persistentSessionDidFetchCategories(state: state, result: result)
@@ -288,7 +288,7 @@ extension AnimalsReducer {
     state: AnimalsState,
     animalId: Animal.ID,
     result: AnimalsAction.Data.PersistentSession.UpdateAnimalResult
-  ) throws -> AnimalsState {
+  ) throws(AnimalsReducer.Error) -> AnimalsState {
     guard let _ = state.animals.data[animalId] else {
       throw AnimalsReducer.Error(code: .animalNotFound)
     }
@@ -309,7 +309,7 @@ extension AnimalsReducer {
     state: AnimalsState,
     animalId: Animal.ID,
     result: AnimalsAction.Data.PersistentSession.DeleteAnimalResult
-  ) throws -> AnimalsState {
+  ) throws(AnimalsReducer.Error) -> AnimalsState {
     guard let _ = state.animals.data[animalId] else {
       throw AnimalsReducer.Error(code: .animalNotFound)
     }

--- a/Samples/AnimalsData/Sources/AnimalsData/Listener.swift
+++ b/Samples/AnimalsData/Sources/AnimalsData/Listener.swift
@@ -39,7 +39,7 @@ extension UserDefaults {
 }
 
 extension Listener {
-  public func listen(to store: some ImmutableData.Dispatcher<AnimalsState, AnimalsAction> & ImmutableData.Selector<AnimalsState> & ImmutableData.Streamer<AnimalsState, AnimalsAction> & AnyObject) {
+  public func listen(to store: some ImmutableData.Dispatcher<AnimalsState, AnimalsAction, AnimalsReducer.Error> & ImmutableData.Selector<AnimalsState> & ImmutableData.Streamer<AnimalsState, AnimalsAction> & AnyObject) {
     if self.store !== store {
       self.store = store
       
@@ -65,7 +65,7 @@ extension Listener {
 
 extension Listener {
   private func onReceive(
-    from store: some ImmutableData.Dispatcher<AnimalsState, AnimalsAction> & ImmutableData.Selector<AnimalsState>,
+    from store: some ImmutableData.Dispatcher<AnimalsState, AnimalsAction, AnimalsReducer.Error> & ImmutableData.Selector<AnimalsState>,
     oldState: AnimalsState,
     action: AnimalsAction
   ) async {
@@ -80,7 +80,7 @@ extension Listener {
 
 extension Listener {
   private func onReceive(
-    from store: some ImmutableData.Dispatcher<AnimalsState, AnimalsAction> & ImmutableData.Selector<AnimalsState>,
+    from store: some ImmutableData.Dispatcher<AnimalsState, AnimalsAction, AnimalsReducer.Error> & ImmutableData.Selector<AnimalsState>,
     oldState: AnimalsState,
     action: AnimalsAction.UI
   ) async {
@@ -99,7 +99,7 @@ extension Listener {
 
 extension Listener {
   private func onReceive(
-    from store: some ImmutableData.Dispatcher<AnimalsState, AnimalsAction> & ImmutableData.Selector<AnimalsState>,
+    from store: some ImmutableData.Dispatcher<AnimalsState, AnimalsAction, AnimalsReducer.Error> & ImmutableData.Selector<AnimalsState>,
     oldState: AnimalsState,
     action: AnimalsAction.UI.CategoryList
   ) async {
@@ -134,7 +134,7 @@ extension Listener {
 
 extension Listener {
   private func onReceive(
-    from store: some ImmutableData.Dispatcher<AnimalsState, AnimalsAction> & ImmutableData.Selector<AnimalsState>,
+    from store: some ImmutableData.Dispatcher<AnimalsState, AnimalsAction, AnimalsReducer.Error> & ImmutableData.Selector<AnimalsState>,
     oldState: AnimalsState,
     action: AnimalsAction.UI.AnimalList
   ) async {
@@ -167,7 +167,7 @@ extension Listener {
 
 extension Listener {
   private func onReceive(
-    from store: some ImmutableData.Dispatcher<AnimalsState, AnimalsAction> & ImmutableData.Selector<AnimalsState>,
+    from store: some ImmutableData.Dispatcher<AnimalsState, AnimalsAction, AnimalsReducer.Error> & ImmutableData.Selector<AnimalsState>,
     oldState: AnimalsState,
     action: AnimalsAction.UI.AnimalDetail
   ) async {
@@ -189,7 +189,7 @@ extension Listener {
 
 extension Listener {
   private func onReceive(
-    from store: some ImmutableData.Dispatcher<AnimalsState, AnimalsAction> & ImmutableData.Selector<AnimalsState>,
+    from store: some ImmutableData.Dispatcher<AnimalsState, AnimalsAction, AnimalsReducer.Error> & ImmutableData.Selector<AnimalsState>,
     oldState: AnimalsState,
     action: AnimalsAction.UI.AnimalEditor
   ) async {

--- a/Samples/AnimalsData/Sources/AnimalsData/PersistentSession.swift
+++ b/Samples/AnimalsData/Sources/AnimalsData/PersistentSession.swift
@@ -49,7 +49,7 @@ extension PersistentSession {
   func fetchAnimalsQuery<Dispatcher, Selector>() -> @Sendable (
     Dispatcher,
     Selector
-  ) async throws -> Void where Dispatcher : ImmutableData.Dispatcher<AnimalsState, AnimalsAction>, Selector : ImmutableData.Selector<AnimalsState> {
+  ) async throws -> Void where Dispatcher : ImmutableData.Dispatcher<AnimalsState, AnimalsAction, AnimalsReducer.Error>, Selector : ImmutableData.Selector<AnimalsState> {
     { dispatcher, selector in
       try await self.fetchAnimalsQuery(
         dispatcher: dispatcher,
@@ -61,7 +61,7 @@ extension PersistentSession {
 
 extension PersistentSession {
   private func fetchAnimalsQuery(
-    dispatcher: some ImmutableData.Dispatcher<AnimalsState, AnimalsAction>,
+    dispatcher: some ImmutableData.Dispatcher<AnimalsState, AnimalsAction, AnimalsReducer.Error>,
     selector: some ImmutableData.Selector<AnimalsState>
   ) async throws {
     let animals = try await {
@@ -105,7 +105,7 @@ extension PersistentSession {
   ) -> @Sendable (
     Dispatcher,
     Selector
-  ) async throws -> Void where Dispatcher : ImmutableData.Dispatcher<AnimalsState, AnimalsAction>, Selector : ImmutableData.Selector<AnimalsState> {
+  ) async throws -> Void where Dispatcher : ImmutableData.Dispatcher<AnimalsState, AnimalsAction, AnimalsReducer.Error>, Selector : ImmutableData.Selector<AnimalsState> {
     { dispatcher, selector in
       try await self.addAnimalMutation(
         dispatcher: dispatcher,
@@ -121,7 +121,7 @@ extension PersistentSession {
 
 extension PersistentSession {
   private func addAnimalMutation(
-    dispatcher: some ImmutableData.Dispatcher<AnimalsState, AnimalsAction>,
+    dispatcher: some ImmutableData.Dispatcher<AnimalsState, AnimalsAction, AnimalsReducer.Error>,
     selector: some ImmutableData.Selector<AnimalsState>,
     id: String,
     name: String,
@@ -175,7 +175,7 @@ extension PersistentSession {
   ) -> @Sendable (
     Dispatcher,
     Selector
-  ) async throws -> Void where Dispatcher : ImmutableData.Dispatcher<AnimalsState, AnimalsAction>, Selector : ImmutableData.Selector<AnimalsState> {
+  ) async throws -> Void where Dispatcher : ImmutableData.Dispatcher<AnimalsState, AnimalsAction, AnimalsReducer.Error>, Selector : ImmutableData.Selector<AnimalsState> {
     { dispatcher, selector in
       try await self.updateAnimalMutation(
         dispatcher: dispatcher,
@@ -191,7 +191,7 @@ extension PersistentSession {
 
 extension PersistentSession {
   private func updateAnimalMutation(
-    dispatcher: some ImmutableData.Dispatcher<AnimalsState, AnimalsAction>,
+    dispatcher: some ImmutableData.Dispatcher<AnimalsState, AnimalsAction, AnimalsReducer.Error>,
     selector: some ImmutableData.Selector<AnimalsState>,
     animalId: String,
     name: String,
@@ -243,7 +243,7 @@ extension PersistentSession {
   ) -> @Sendable (
     Dispatcher,
     Selector
-  ) async throws -> Void where Dispatcher : ImmutableData.Dispatcher<AnimalsState, AnimalsAction>, Selector : ImmutableData.Selector<AnimalsState> {
+  ) async throws -> Void where Dispatcher : ImmutableData.Dispatcher<AnimalsState, AnimalsAction, AnimalsReducer.Error>, Selector : ImmutableData.Selector<AnimalsState> {
     { dispatcher, selector in
       try await self.deleteAnimalMutation(
         dispatcher: dispatcher,
@@ -256,7 +256,7 @@ extension PersistentSession {
 
 extension PersistentSession {
   private func deleteAnimalMutation(
-    dispatcher: some ImmutableData.Dispatcher<AnimalsState, AnimalsAction>,
+    dispatcher: some ImmutableData.Dispatcher<AnimalsState, AnimalsAction, AnimalsReducer.Error>,
     selector: some ImmutableData.Selector<AnimalsState>,
     animalId: String
   ) async throws {
@@ -300,7 +300,7 @@ extension PersistentSession {
   func fetchCategoriesQuery<Dispatcher, Selector>() -> @Sendable (
     Dispatcher,
     Selector
-  ) async throws -> Void where Dispatcher : ImmutableData.Dispatcher<AnimalsState, AnimalsAction>, Selector : ImmutableData.Selector<AnimalsState> {
+  ) async throws -> Void where Dispatcher : ImmutableData.Dispatcher<AnimalsState, AnimalsAction, AnimalsReducer.Error>, Selector : ImmutableData.Selector<AnimalsState> {
     { dispatcher, selector in
       try await self.fetchCategoriesQuery(
         dispatcher: dispatcher,
@@ -312,7 +312,7 @@ extension PersistentSession {
 
 extension PersistentSession {
   private func fetchCategoriesQuery(
-    dispatcher: some ImmutableData.Dispatcher<AnimalsState, AnimalsAction>,
+    dispatcher: some ImmutableData.Dispatcher<AnimalsState, AnimalsAction, AnimalsReducer.Error>,
     selector: some ImmutableData.Selector<AnimalsState>
   ) async throws {
     let categories = try await {
@@ -351,7 +351,7 @@ extension PersistentSession {
   func reloadSampleDataMutation<Dispatcher, Selector>() -> @Sendable (
     Dispatcher,
     Selector
-  ) async throws -> Void where Dispatcher : ImmutableData.Dispatcher<AnimalsState, AnimalsAction>, Selector : ImmutableData.Selector<AnimalsState> {
+  ) async throws -> Void where Dispatcher : ImmutableData.Dispatcher<AnimalsState, AnimalsAction, AnimalsReducer.Error>, Selector : ImmutableData.Selector<AnimalsState> {
     { dispatcher, selector in
       try await self.reloadSampleDataMutation(
         dispatcher: dispatcher,
@@ -363,7 +363,7 @@ extension PersistentSession {
 
 extension PersistentSession {
   private func reloadSampleDataMutation(
-    dispatcher: some ImmutableData.Dispatcher<AnimalsState, AnimalsAction>,
+    dispatcher: some ImmutableData.Dispatcher<AnimalsState, AnimalsAction, AnimalsReducer.Error>,
     selector: some ImmutableData.Selector<AnimalsState>
   ) async throws {
     let (animals, categories) = try await {

--- a/Samples/AnimalsData/Tests/AnimalsDataTests/ListenerTests.swift
+++ b/Samples/AnimalsData/Tests/AnimalsDataTests/ListenerTests.swift
@@ -148,7 +148,7 @@ extension PersistentSessionPersistentStoreTestDouble {
 }
 
 extension StoreTestDouble : ImmutableData.Dispatcher {
-  func dispatch(action: Action) throws {
+  func dispatch(action: Action) throws(AnimalsReducer.Error) {
     self.parameterAction.append(action)
   }
   

--- a/Samples/AnimalsUI/Sources/AnimalsUI/Dispatch.swift
+++ b/Samples/AnimalsUI/Sources/AnimalsUI/Dispatch.swift
@@ -26,7 +26,7 @@ import SwiftUI
     
   }
   
-  var wrappedValue: (AnimalsAction) throws -> Void {
+  var wrappedValue: (AnimalsAction) throws(AnimalsReducer.Error) -> Void {
     self.dispatcher.dispatch
   }
 }

--- a/Samples/AnimalsUI/Sources/AnimalsUI/PreviewStore.swift
+++ b/Samples/AnimalsUI/Sources/AnimalsUI/PreviewStore.swift
@@ -20,7 +20,7 @@ import ImmutableUI
 import SwiftUI
 
 @MainActor struct PreviewStore<Content> where Content : View {
-  @State private var store: ImmutableData.Store<AnimalsState, AnimalsAction> = {
+  @State private var store: ImmutableData.Store<AnimalsState, AnimalsAction, AnimalsReducer.Error> = {
     do {
       let store = ImmutableData.Store(
         initialState: AnimalsState(),

--- a/Samples/AnimalsUI/Sources/AnimalsUI/Select.swift
+++ b/Samples/AnimalsUI/Sources/AnimalsUI/Select.swift
@@ -39,7 +39,7 @@ extension ImmutableUI.Selector {
     filter isIncluded: (@Sendable (Store.State, Store.Action) -> Bool)? = nil,
     dependencySelector: repeat @escaping @Sendable (Store.State) -> each Dependency,
     outputSelector: @escaping @Sendable (Store.State) -> Output
-  ) where Store == ImmutableData.Store<AnimalsState, AnimalsAction>, repeat each Dependency : Equatable, Output : Equatable {
+  ) where Store == ImmutableData.Store<AnimalsState, AnimalsAction, AnimalsReducer.Error>, repeat each Dependency : Equatable, Output : Equatable {
     self.init(
       id: id,
       label: label,
@@ -56,7 +56,7 @@ extension ImmutableUI.Selector {
     filter isIncluded: (@Sendable (Store.State, Store.Action) -> Bool)? = nil,
     dependencySelector: repeat @escaping @Sendable (Store.State) -> each Dependency,
     outputSelector: @escaping @Sendable (Store.State) -> Output
-  ) where Store == ImmutableData.Store<AnimalsState, AnimalsAction>, repeat each Dependency : Equatable, Output : Equatable {
+  ) where Store == ImmutableData.Store<AnimalsState, AnimalsAction, AnimalsReducer.Error>, repeat each Dependency : Equatable, Output : Equatable {
     self.init(
       label: label,
       filter: isIncluded,
@@ -91,7 +91,7 @@ extension ImmutableUI.Selector {
 }
 
 @MainActor @propertyWrapper struct SelectCategory: DynamicProperty {
-  @ImmutableUI.Selector<ImmutableData.Store<AnimalsState, AnimalsAction>, AnimalsData.Category?> var wrappedValue: AnimalsData.Category?
+  @ImmutableUI.Selector<ImmutableData.Store<AnimalsState, AnimalsAction, AnimalsReducer.Error>, AnimalsData.Category?> var wrappedValue: AnimalsData.Category?
   
   init(categoryId: AnimalsData.Category.ID?) {
     self._wrappedValue = ImmutableUI.Selector(
@@ -111,7 +111,7 @@ extension ImmutableUI.Selector {
 }
 
 @MainActor @propertyWrapper struct SelectAnimalsValues: DynamicProperty {
-  @ImmutableUI.Selector<ImmutableData.Store<AnimalsState, AnimalsAction>, TreeDictionary<Animal.ID, Animal>, Array<Animal>> var wrappedValue: Array<Animal>
+  @ImmutableUI.Selector<ImmutableData.Store<AnimalsState, AnimalsAction, AnimalsReducer.Error>, TreeDictionary<Animal.ID, Animal>, Array<Animal>> var wrappedValue: Array<Animal>
   
   init(categoryId: AnimalsData.Category.ID?) {
     self._wrappedValue = ImmutableUI.Selector(
@@ -139,7 +139,7 @@ extension ImmutableUI.Selector {
 }
 
 @MainActor @propertyWrapper struct SelectAnimal: DynamicProperty {
-  @ImmutableUI.Selector<ImmutableData.Store<AnimalsState, AnimalsAction>, Animal?> var wrappedValue: Animal?
+  @ImmutableUI.Selector<ImmutableData.Store<AnimalsState, AnimalsAction, AnimalsReducer.Error>, Animal?> var wrappedValue: Animal?
   
   init(animalId: Animal.ID?) {
     self._wrappedValue = ImmutableUI.Selector(
@@ -151,7 +151,7 @@ extension ImmutableUI.Selector {
 }
 
 @MainActor @propertyWrapper struct SelectAnimalStatus: DynamicProperty {
-  @ImmutableUI.Selector<ImmutableData.Store<AnimalsState, AnimalsAction>, Status?> var wrappedValue: Status?
+  @ImmutableUI.Selector<ImmutableData.Store<AnimalsState, AnimalsAction, AnimalsReducer.Error>, Status?> var wrappedValue: Status?
   
   init(animalId: Animal.ID?) {
     self._wrappedValue = ImmutableUI.Selector(

--- a/Samples/AnimalsUI/Sources/AnimalsUI/StoreKey.swift
+++ b/Samples/AnimalsUI/Sources/AnimalsUI/StoreKey.swift
@@ -25,7 +25,7 @@ extension ImmutableUI.Provider {
   public init(
     _ store: Store,
     @ViewBuilder content: () -> Content
-  ) where Store == ImmutableData.Store<AnimalsState, AnimalsAction> {
+  ) where Store == ImmutableData.Store<AnimalsState, AnimalsAction, AnimalsReducer.Error> {
     self.init(
       \.store,
        store,
@@ -35,7 +35,7 @@ extension ImmutableUI.Provider {
 }
 
 extension ImmutableUI.Dispatcher {
-  public init() where Store == ImmutableData.Store<AnimalsState, AnimalsAction> {
+  public init() where Store == ImmutableData.Store<AnimalsState, AnimalsAction, AnimalsReducer.Error> {
     self.init(\.store)
   }
 }
@@ -47,7 +47,7 @@ extension ImmutableUI.Selector {
     filter isIncluded: (@Sendable (Store.State, Store.Action) -> Bool)? = nil,
     dependencySelector: repeat DependencySelector<Store.State, each Dependency>,
     outputSelector: OutputSelector<Store.State, Output>
-  ) where Store == ImmutableData.Store<AnimalsState, AnimalsAction> {
+  ) where Store == ImmutableData.Store<AnimalsState, AnimalsAction, AnimalsReducer.Error> {
     self.init(
       \.store,
        id: id,
@@ -65,7 +65,7 @@ extension ImmutableUI.Selector {
     filter isIncluded: (@Sendable (Store.State, Store.Action) -> Bool)? = nil,
     dependencySelector: repeat DependencySelector<Store.State, each Dependency>,
     outputSelector: OutputSelector<Store.State, Output>
-  ) where Store == ImmutableData.Store<AnimalsState, AnimalsAction> {
+  ) where Store == ImmutableData.Store<AnimalsState, AnimalsAction, AnimalsReducer.Error> {
     self.init(
       \.store,
        label: label,
@@ -84,7 +84,7 @@ extension ImmutableUI.Selector {
 }
 
 extension EnvironmentValues {
-  fileprivate var store: ImmutableData.Store<AnimalsState, AnimalsAction> {
+  fileprivate var store: ImmutableData.Store<AnimalsState, AnimalsAction, AnimalsReducer.Error> {
     get {
       self[StoreKey.self]
     }

--- a/Samples/CounterUI/Sources/CounterUI/Content.swift
+++ b/Samples/CounterUI/Sources/CounterUI/Content.swift
@@ -51,21 +51,13 @@ extension Content : View {
 
 extension Content {
   private func didTapIncrementButton() {
-    do {
-      try self.dispatch(.didTapIncrementButton)
-    } catch {
-      print(error)
-    }
+    self.dispatch(.didTapIncrementButton)
   }
 }
 
 extension Content {
   private func didTapDecrementButton() {
-    do {
-      try self.dispatch(.didTapDecrementButton)
-    } catch {
-      print(error)
-    }
+    self.dispatch(.didTapDecrementButton)
   }
 }
 
@@ -84,23 +76,23 @@ extension Content {
   }
 }
 
-fileprivate struct CounterError : Swift.Error {
-  let state: CounterState
-  let action: CounterAction
-}
-
-#Preview {
-  @Previewable @State var store = ImmutableData.Store(
-    initialState: CounterState(),
-    reducer: { (state: CounterState, action: CounterAction) -> (CounterState) in
-      throw CounterError(
-        state: state,
-        action: action
-      )
-    }
-  )
-  
-  Provider(store) {
-    Content()
-  }
-}
+//fileprivate struct CounterError : Swift.Error {
+//  let state: CounterState
+//  let action: CounterAction
+//}
+//
+//#Preview {
+//  @Previewable @State var store = ImmutableData.Store(
+//    initialState: CounterState(),
+//    reducer: { (state: CounterState, action: CounterAction) throws(CounterError) -> (CounterState) in
+//      throw CounterError(
+//        state: state,
+//        action: action
+//      )
+//    }
+//  )
+//  
+//  Provider(store) {
+//    Content()
+//  }
+//}

--- a/Samples/CounterUI/Sources/CounterUI/Dispatch.swift
+++ b/Samples/CounterUI/Sources/CounterUI/Dispatch.swift
@@ -20,13 +20,13 @@ import ImmutableUI
 import SwiftUI
 
 @MainActor @propertyWrapper struct Dispatch : DynamicProperty {
-  @ImmutableUI.Dispatcher() private var dispatcher
-  
+  @ImmutableUI.Dispatcher<Store>() private var dispatcher
+
   init() {
     
   }
   
-  var wrappedValue: (CounterAction) throws -> () {
+  var wrappedValue: (CounterAction) -> () {
     self.dispatcher.dispatch
   }
 }

--- a/Samples/CounterUI/Sources/CounterUI/Select.swift
+++ b/Samples/CounterUI/Sources/CounterUI/Select.swift
@@ -38,7 +38,7 @@ extension ImmutableUI.Selector {
     filter isIncluded: (@Sendable (Store.State, Store.Action) -> Bool)? = nil,
     dependencySelector: repeat @escaping @Sendable (Store.State) -> each Dependency,
     outputSelector: @escaping @Sendable (Store.State) -> Output
-  ) where Store == ImmutableData.Store<CounterState, CounterAction>, repeat each Dependency : Equatable, Output : Equatable {
+  ) where Store == ImmutableData.Store<CounterState, CounterAction, Never>, repeat each Dependency : Equatable, Output : Equatable {
     self.init(
       id: id,
       label: label,
@@ -55,7 +55,7 @@ extension ImmutableUI.Selector {
     filter isIncluded: (@Sendable (Store.State, Store.Action) -> Bool)? = nil,
     dependencySelector: repeat @escaping @Sendable (Store.State) -> each Dependency,
     outputSelector: @escaping @Sendable (Store.State) -> Output
-  ) where Store == ImmutableData.Store<CounterState, CounterAction>, repeat each Dependency : Equatable, Output : Equatable {
+  ) where Store == ImmutableData.Store<CounterState, CounterAction, Never>, repeat each Dependency : Equatable, Output : Equatable {
     self.init(
       label: label,
       filter: isIncluded,

--- a/Samples/CounterUI/Sources/CounterUI/StoreKey.swift
+++ b/Samples/CounterUI/Sources/CounterUI/StoreKey.swift
@@ -25,7 +25,7 @@ extension ImmutableUI.Provider {
   public init(
     _ store: Store,
     @ViewBuilder content: () -> Content
-  ) where Store == ImmutableData.Store<CounterState, CounterAction> {
+  ) where Store == ImmutableData.Store<CounterState, CounterAction, Never> {
     self.init(
       \.store,
        store,
@@ -35,7 +35,7 @@ extension ImmutableUI.Provider {
 }
 
 extension ImmutableUI.Dispatcher {
-  public init() where Store == ImmutableData.Store<CounterState, CounterAction> {
+  public init() where Store == ImmutableData.Store<CounterState, CounterAction, Never> {
     self.init(\.store)
   }
 }
@@ -47,7 +47,7 @@ extension ImmutableUI.Selector {
     filter isIncluded: (@Sendable (Store.State, Store.Action) -> Bool)? = nil,
     dependencySelector: repeat DependencySelector<Store.State, each Dependency>,
     outputSelector: OutputSelector<Store.State, Output>
-  ) where Store == ImmutableData.Store<CounterState, CounterAction> {
+  ) where Store == ImmutableData.Store<CounterState, CounterAction, Never> {
     self.init(
       \.store,
        id: id,
@@ -65,7 +65,7 @@ extension ImmutableUI.Selector {
     filter isIncluded: (@Sendable (Store.State, Store.Action) -> Bool)? = nil,
     dependencySelector: repeat DependencySelector<Store.State, each Dependency>,
     outputSelector: OutputSelector<Store.State, Output>
-  ) where Store == ImmutableData.Store<CounterState, CounterAction> {
+  ) where Store == ImmutableData.Store<CounterState, CounterAction, Never> {
     self.init(
       \.store,
        label: label,
@@ -84,7 +84,7 @@ extension ImmutableUI.Selector {
 }
 
 extension EnvironmentValues {
-  fileprivate var store: ImmutableData.Store<CounterState, CounterAction> {
+  /*fileprivate*/ var store: ImmutableData.Store<CounterState, CounterAction, Never> {
     get {
       self[StoreKey.self]
     }

--- a/Samples/QuakesData/Sources/QuakesData/Listener.swift
+++ b/Samples/QuakesData/Sources/QuakesData/Listener.swift
@@ -45,7 +45,7 @@ extension UserDefaults {
 }
 
 extension Listener {
-  public func listen(to store: some ImmutableData.Dispatcher<QuakesState, QuakesAction> & ImmutableData.Selector<QuakesState> & ImmutableData.Streamer<QuakesState, QuakesAction> & AnyObject) {
+  public func listen(to store: some ImmutableData.Dispatcher<QuakesState, QuakesAction, QuakesReducer.Error> & ImmutableData.Selector<QuakesState> & ImmutableData.Streamer<QuakesState, QuakesAction> & AnyObject) {
     if self.store !== store {
       self.store = store
       
@@ -72,7 +72,7 @@ extension Listener {
 
 extension Listener {
   private func onReceive(
-    from store: some ImmutableData.Dispatcher<QuakesState, QuakesAction> & ImmutableData.Selector<QuakesState>,
+    from store: some ImmutableData.Dispatcher<QuakesState, QuakesAction, QuakesReducer.Error> & ImmutableData.Selector<QuakesState>,
     oldState: QuakesState,
     action: QuakesAction
   ) async {
@@ -87,7 +87,7 @@ extension Listener {
 
 extension Listener {
   private func onReceive(
-    from store: some ImmutableData.Dispatcher<QuakesState, QuakesAction> & ImmutableData.Selector<QuakesState>,
+    from store: some ImmutableData.Dispatcher<QuakesState, QuakesAction, QuakesReducer.Error> & ImmutableData.Selector<QuakesState>,
     oldState: QuakesState,
     action: QuakesAction.UI.QuakeList
   ) async {
@@ -136,7 +136,7 @@ extension Listener {
 
 extension Listener {
   private func onReceive(
-    from store: some ImmutableData.Dispatcher<QuakesState, QuakesAction> & ImmutableData.Selector<QuakesState>,
+    from store: some ImmutableData.Dispatcher<QuakesState, QuakesAction, QuakesReducer.Error> & ImmutableData.Selector<QuakesState>,
     oldState: QuakesState,
     action: QuakesAction.Data.PersistentSession
   ) async {
@@ -151,7 +151,7 @@ extension Listener {
 
 extension Listener {
   private func onReceive(
-    from store: some ImmutableData.Dispatcher<QuakesState, QuakesAction> & ImmutableData.Selector<QuakesState>,
+    from store: some ImmutableData.Dispatcher<QuakesState, QuakesAction, QuakesReducer.Error> & ImmutableData.Selector<QuakesState>,
     oldState: QuakesState,
     action: QuakesAction.Data.PersistentSession.LocalStore
   ) async {
@@ -164,7 +164,7 @@ extension Listener {
 
 extension Listener {
   private func onReceive(
-    from store: some ImmutableData.Dispatcher<QuakesState, QuakesAction> & ImmutableData.Selector<QuakesState>,
+    from store: some ImmutableData.Dispatcher<QuakesState, QuakesAction, QuakesReducer.Error> & ImmutableData.Selector<QuakesState>,
     oldState: QuakesState,
     action: QuakesAction.Data.PersistentSession.RemoteStore
   ) async {

--- a/Samples/QuakesData/Sources/QuakesData/PersistentSession.swift
+++ b/Samples/QuakesData/Sources/QuakesData/PersistentSession.swift
@@ -46,7 +46,7 @@ final actor PersistentSession<LocalStore, RemoteStore> where LocalStore : Persis
 
 extension PersistentSession {
   private func fetchLocalQuakesQuery(
-    dispatcher: some ImmutableData.Dispatcher<QuakesState, QuakesAction>,
+    dispatcher: some ImmutableData.Dispatcher<QuakesState, QuakesAction, QuakesReducer.Error>,
     selector: some ImmutableData.Selector<QuakesState>
   ) async throws {
     let quakes = try await {
@@ -89,7 +89,7 @@ extension PersistentSession {
   func fetchLocalQuakesQuery<Dispatcher, Selector>() -> @Sendable (
     Dispatcher,
     Selector
-  ) async throws -> Void where Dispatcher: ImmutableData.Dispatcher<QuakesState, QuakesAction>, Selector: ImmutableData.Selector<QuakesState> {
+  ) async throws -> Void where Dispatcher: ImmutableData.Dispatcher<QuakesState, QuakesAction, QuakesReducer.Error>, Selector: ImmutableData.Selector<QuakesState> {
     { dispatcher, selector in
       try await self.fetchLocalQuakesQuery(
         dispatcher: dispatcher,
@@ -101,7 +101,7 @@ extension PersistentSession {
 
 extension PersistentSession {
   private func didFetchRemoteQuakesMutation(
-    dispatcher: some ImmutableData.Dispatcher<QuakesState, QuakesAction>,
+    dispatcher: some ImmutableData.Dispatcher<QuakesState, QuakesAction, QuakesReducer.Error>,
     selector: some ImmutableData.Selector<QuakesState>,
     inserted: Array<Quake>,
     updated: Array<Quake>,
@@ -123,7 +123,7 @@ extension PersistentSession {
   ) -> @Sendable (
     Dispatcher,
     Selector
-  ) async throws -> Void where Dispatcher: ImmutableData.Dispatcher<QuakesState, QuakesAction>, Selector: ImmutableData.Selector<QuakesState> {
+  ) async throws -> Void where Dispatcher: ImmutableData.Dispatcher<QuakesState, QuakesAction, QuakesReducer.Error>, Selector: ImmutableData.Selector<QuakesState> {
     { dispatcher, selector in
       try await self.didFetchRemoteQuakesMutation(
         dispatcher: dispatcher,
@@ -138,7 +138,7 @@ extension PersistentSession {
 
 extension PersistentSession {
   private func deleteLocalQuakeMutation(
-    dispatcher: some ImmutableData.Dispatcher<QuakesState, QuakesAction>,
+    dispatcher: some ImmutableData.Dispatcher<QuakesState, QuakesAction, QuakesReducer.Error>,
     selector: some ImmutableData.Selector<QuakesState>,
     quakeId: Quake.ID
   ) async throws {
@@ -150,7 +150,7 @@ extension PersistentSession {
   func deleteLocalQuakeMutation<Dispatcher, Selector>(quakeId: Quake.ID) async throws -> @Sendable (
     Dispatcher,
     Selector
-  ) async throws -> Void where Dispatcher: ImmutableData.Dispatcher<QuakesState, QuakesAction>, Selector: ImmutableData.Selector<QuakesState> {
+  ) async throws -> Void where Dispatcher: ImmutableData.Dispatcher<QuakesState, QuakesAction, QuakesReducer.Error>, Selector: ImmutableData.Selector<QuakesState> {
     { dispatcher, selector in
       try await self.deleteLocalQuakeMutation(
         dispatcher: dispatcher,
@@ -163,7 +163,7 @@ extension PersistentSession {
 
 extension PersistentSession {
   private func deleteLocalQuakesMutation(
-    dispatcher: some ImmutableData.Dispatcher<QuakesState, QuakesAction>,
+    dispatcher: some ImmutableData.Dispatcher<QuakesState, QuakesAction, QuakesReducer.Error>,
     selector: some ImmutableData.Selector<QuakesState>
   ) async throws {
     try await self.localStore.deleteLocalQuakesMutation()
@@ -174,7 +174,7 @@ extension PersistentSession {
   func deleteLocalQuakesMutation<Dispatcher, Selector>() -> @Sendable (
     Dispatcher,
     Selector
-  ) async throws -> Void where Dispatcher: ImmutableData.Dispatcher<QuakesState, QuakesAction>, Selector: ImmutableData.Selector<QuakesState> {
+  ) async throws -> Void where Dispatcher: ImmutableData.Dispatcher<QuakesState, QuakesAction, QuakesReducer.Error>, Selector: ImmutableData.Selector<QuakesState> {
     { dispatcher, selector in
       try await self.deleteLocalQuakesMutation(
         dispatcher: dispatcher,
@@ -186,7 +186,7 @@ extension PersistentSession {
 
 extension PersistentSession {
   private func fetchRemoteQuakesQuery(
-    dispatcher: some ImmutableData.Dispatcher<QuakesState, QuakesAction>,
+    dispatcher: some ImmutableData.Dispatcher<QuakesState, QuakesAction, QuakesReducer.Error>,
     selector: some ImmutableData.Selector<QuakesState>,
     range: QuakesAction.UI.QuakeList.RefreshQuakesRange
   ) async throws {
@@ -231,7 +231,7 @@ extension PersistentSession {
   ) -> @Sendable (
     Dispatcher,
     Selector
-  ) async throws -> Void where Dispatcher: ImmutableData.Dispatcher<QuakesState, QuakesAction>, Selector: ImmutableData.Selector<QuakesState> {
+  ) async throws -> Void where Dispatcher: ImmutableData.Dispatcher<QuakesState, QuakesAction, QuakesReducer.Error>, Selector: ImmutableData.Selector<QuakesState> {
     { dispatcher, selector in
       try await self.fetchRemoteQuakesQuery(
         dispatcher: dispatcher,

--- a/Samples/QuakesData/Sources/QuakesData/QuakesReducer.swift
+++ b/Samples/QuakesData/Sources/QuakesData/QuakesReducer.swift
@@ -18,7 +18,7 @@ public enum QuakesReducer {
   @Sendable public static func reduce(
     state: QuakesState,
     action: QuakesAction
-  ) throws -> QuakesState {
+  ) throws(QuakesReducer.Error) -> QuakesState {
     switch action {
     case .ui(.quakeList(action: let action)):
       return try self.reduce(state: state, action: action)
@@ -32,7 +32,7 @@ extension QuakesReducer {
   private static func reduce(
     state: QuakesState,
     action: QuakesAction.UI.QuakeList
-  ) throws -> QuakesState {
+  ) throws(QuakesReducer.Error) -> QuakesState {
     switch action {
     case .onAppear:
       return self.onAppear(state: state)
@@ -69,12 +69,12 @@ extension QuakesReducer {
 }
 
 extension QuakesReducer {
-  package struct Error: Swift.Error {
-    package enum Code: Hashable, Sendable {
+  public struct Error: Swift.Error {
+    public enum Code: Hashable, Sendable {
       case quakeNotFound
     }
     
-    package let code: Self.Code
+    public let code: Self.Code
   }
 }
 
@@ -82,7 +82,7 @@ extension QuakesReducer {
   private static func deleteSelectedQuake(
     state: QuakesState,
     quakeId: Quake.ID
-  ) throws -> QuakesState {
+  ) throws(QuakesReducer.Error) -> QuakesState {
     guard let _ = state.quakes.data[quakeId] else {
       throw Error(code: .quakeNotFound)
     }
@@ -104,7 +104,7 @@ extension QuakesReducer {
   private static func reduce(
     state: QuakesState,
     action: QuakesAction.Data.PersistentSession
-  ) throws -> QuakesState {
+  ) throws(QuakesReducer.Error) -> QuakesState {
     switch action {
     case .localStore(.didFetchQuakes(result: let result)):
       return self.didFetchQuakes(state: state, result: result)

--- a/Samples/QuakesData/Tests/QuakesDataTests/ListenerTests.swift
+++ b/Samples/QuakesData/Tests/QuakesDataTests/ListenerTests.swift
@@ -163,7 +163,7 @@ final fileprivate class DidFetchRemoteQuakesMutationLocalStoreTestDouble : @unch
 }
 
 extension StoreTestDouble : ImmutableData.Dispatcher {
-  func dispatch(action: Action) throws {
+  func dispatch(action: Action) throws(QuakesReducer.Error) {
     self.parameterAction.append(action)
   }
   

--- a/Samples/QuakesUI/Sources/QuakesUI/Dispatch.swift
+++ b/Samples/QuakesUI/Sources/QuakesUI/Dispatch.swift
@@ -26,7 +26,7 @@ import SwiftUI
     
   }
   
-  var wrappedValue: (QuakesAction) throws -> Void {
+  var wrappedValue: (QuakesAction) throws(QuakesReducer.Error) -> Void {
     self.dispatcher.dispatch
   }
 }

--- a/Samples/QuakesUI/Sources/QuakesUI/PreviewStore.swift
+++ b/Samples/QuakesUI/Sources/QuakesUI/PreviewStore.swift
@@ -20,7 +20,7 @@ import QuakesData
 import SwiftUI
 
 @MainActor struct PreviewStore<Content> where Content : View {
-  @State private var store: ImmutableData.Store<QuakesState, QuakesAction> = {
+  @State private var store: ImmutableData.Store<QuakesState, QuakesAction, QuakesReducer.Error> = {
     do {
       let store = ImmutableData.Store(
         initialState: QuakesState(),

--- a/Samples/QuakesUI/Sources/QuakesUI/Select.swift
+++ b/Samples/QuakesUI/Sources/QuakesUI/Select.swift
@@ -39,7 +39,7 @@ extension ImmutableUI.Selector {
     filter isIncluded: (@Sendable (Store.State, Store.Action) -> Bool)? = nil,
     dependencySelector: repeat @escaping @Sendable (Store.State) -> each Dependency,
     outputSelector: @escaping @Sendable (Store.State) -> Output
-  ) where Store == ImmutableData.Store<QuakesState, QuakesAction>, repeat each Dependency : Equatable, Output : Equatable {
+  ) where Store == ImmutableData.Store<QuakesState, QuakesAction, QuakesReducer.Error>, repeat each Dependency : Equatable, Output : Equatable {
     self.init(
        id: id,
        label: label,
@@ -56,7 +56,7 @@ extension ImmutableUI.Selector {
     filter isIncluded: (@Sendable (Store.State, Store.Action) -> Bool)? = nil,
     dependencySelector: repeat @escaping @Sendable (Store.State) -> each Dependency,
     outputSelector: @escaping @Sendable (Store.State) -> Output
-  ) where Store == ImmutableData.Store<QuakesState, QuakesAction>, repeat each Dependency : Equatable, Output : Equatable {
+  ) where Store == ImmutableData.Store<QuakesState, QuakesAction, QuakesReducer.Error>, repeat each Dependency : Equatable, Output : Equatable {
     self.init(
        label: label,
        filter: isIncluded,
@@ -67,7 +67,7 @@ extension ImmutableUI.Selector {
 }
 
 @MainActor @propertyWrapper struct SelectQuakes: DynamicProperty {
-  @ImmutableUI.Selector<ImmutableData.Store<QuakesState, QuakesAction>, TreeDictionary<Quake.ID, Quake>> var wrappedValue: TreeDictionary<Quake.ID, Quake>
+  @ImmutableUI.Selector<ImmutableData.Store<QuakesState, QuakesAction, QuakesReducer.Error>, TreeDictionary<Quake.ID, Quake>> var wrappedValue: TreeDictionary<Quake.ID, Quake>
   
   init(
     searchText: String,
@@ -96,7 +96,7 @@ extension SelectQuakes {
 }
 
 @MainActor @propertyWrapper struct SelectQuakesValues: DynamicProperty {
-  @ImmutableUI.Selector<ImmutableData.Store<QuakesState, QuakesAction>, TreeDictionary<Quake.ID, Quake>, Array<Quake>> var wrappedValue: Array<Quake>
+  @ImmutableUI.Selector<ImmutableData.Store<QuakesState, QuakesAction, QuakesReducer.Error>, TreeDictionary<Quake.ID, Quake>, Array<Quake>> var wrappedValue: Array<Quake>
   
   init(
     searchText: String,
@@ -137,7 +137,7 @@ extension SelectQuakesValues {
 }
 
 @MainActor @propertyWrapper struct SelectQuakesCount: DynamicProperty {
-  @ImmutableUI.Selector<ImmutableData.Store<QuakesState, QuakesAction>, Int>(
+  @ImmutableUI.Selector<ImmutableData.Store<QuakesState, QuakesAction, QuakesReducer.Error>, Int>(
     label: "SelectQuakesCount",
     outputSelector: QuakesState.selectQuakesCount()
   ) var wrappedValue: Int
@@ -148,7 +148,7 @@ extension SelectQuakesValues {
 }
 
 @MainActor @propertyWrapper struct SelectQuakesStatus: DynamicProperty {
-  @ImmutableUI.Selector<ImmutableData.Store<QuakesState, QuakesAction>, Status?>(
+  @ImmutableUI.Selector<ImmutableData.Store<QuakesState, QuakesAction, QuakesReducer.Error>, Status?>(
     label: "SelectQuakesStatus",
     outputSelector: QuakesState.selectQuakesStatus()
   ) var wrappedValue: Status?
@@ -159,7 +159,7 @@ extension SelectQuakesValues {
 }
 
 @MainActor @propertyWrapper struct SelectQuake: DynamicProperty {
-  @ImmutableUI.Selector<ImmutableData.Store<QuakesState, QuakesAction>, Quake?> var wrappedValue: Quake?
+  @ImmutableUI.Selector<ImmutableData.Store<QuakesState, QuakesAction, QuakesReducer.Error>, Quake?> var wrappedValue: Quake?
   
   init(quakeId: String?) {
     self._wrappedValue = ImmutableUI.Selector(

--- a/Samples/QuakesUI/Sources/QuakesUI/StoreKey.swift
+++ b/Samples/QuakesUI/Sources/QuakesUI/StoreKey.swift
@@ -27,7 +27,7 @@ extension ImmutableUI.Provider {
   public init(
     _ store: Store,
     @ViewBuilder content: () -> Content
-  ) where Store == ImmutableData.Store<QuakesState, QuakesAction> {
+  ) where Store == ImmutableData.Store<QuakesState, QuakesAction, QuakesReducer.Error> {
     self.init(
       \.store,
        store,
@@ -37,7 +37,7 @@ extension ImmutableUI.Provider {
 }
 
 extension ImmutableUI.Dispatcher {
-  public init() where Store == ImmutableData.Store<QuakesState, QuakesAction> {
+  public init() where Store == ImmutableData.Store<QuakesState, QuakesAction, QuakesReducer.Error> {
     self.init(\.store)
   }
 }
@@ -49,7 +49,7 @@ extension ImmutableUI.Selector {
     filter isIncluded: (@Sendable (Store.State, Store.Action) -> Bool)? = nil,
     dependencySelector: repeat DependencySelector<Store.State, each Dependency>,
     outputSelector: OutputSelector<Store.State, Output>
-  ) where Store == ImmutableData.Store<QuakesState, QuakesAction> {
+  ) where Store == ImmutableData.Store<QuakesState, QuakesAction, QuakesReducer.Error> {
     self.init(
       \.store,
        id: id,
@@ -67,7 +67,7 @@ extension ImmutableUI.Selector {
     filter isIncluded: (@Sendable (Store.State, Store.Action) -> Bool)? = nil,
     dependencySelector: repeat DependencySelector<Store.State, each Dependency>,
     outputSelector: OutputSelector<Store.State, Output>
-  ) where Store == ImmutableData.Store<QuakesState, QuakesAction> {
+  ) where Store == ImmutableData.Store<QuakesState, QuakesAction, QuakesReducer.Error> {
     self.init(
       \.store,
        label: label,
@@ -86,7 +86,7 @@ extension ImmutableUI.Selector {
 }
 
 extension EnvironmentValues {
-  fileprivate var store: ImmutableData.Store<QuakesState, QuakesAction> {
+  fileprivate var store: ImmutableData.Store<QuakesState, QuakesAction, QuakesReducer.Error> {
     get {
       self[StoreKey.self]
     }

--- a/Sources/ImmutableData/Dispatcher.swift
+++ b/Sources/ImmutableData/Dispatcher.swift
@@ -15,8 +15,8 @@
 //
 
 /// An interface that dispatches events that could affect change on the global state of our application.
-public protocol Dispatcher<State, Action>: Sendable {
-  
+public protocol Dispatcher<State, Action, Error>: Sendable {
+
   /// The global state of our application.
   ///
   /// - Important: `State` values are modeled as immutable value-types -- *not* mutable reference-types.
@@ -37,13 +37,18 @@ public protocol Dispatcher<State, Action>: Sendable {
   /// - SeeAlso: The `Action` type serves a similar role as the [Action](https://redux.js.org/understanding/thinking-in-redux/glossary#action) type in Redux.
   associatedtype Action: Sendable
   
+  /// The error thrown while dispatching the ``Action``.
+  ///
+  /// Action dispatchers that do not fail can set this to `Never`.
+  associatedtype Error: Swift.Error
+
   /// A ``/ImmutableData/Dispatcher`` type for affecting change on the global state of our application.
   ///
   /// This type is passed to the `dispatch(thunk:)` functions.
   ///
   /// This type can be the same type we just dispatched from -- but this is not explicitly required.
-  associatedtype Dispatcher: ImmutableData.Dispatcher<Self.State, Self.Action>
-  
+  associatedtype Dispatcher: ImmutableData.Dispatcher<Self.State, Self.Action, Self.Error>
+
   /// A ``/ImmutableData/Selector`` type for selecting a slice of the global state of our application.
   ///
   /// This type is passed to the `dispatch(thunk:)` functions.
@@ -56,11 +61,11 @@ public protocol Dispatcher<State, Action>: Sendable {
   ///
   /// - Parameter action: An event that could affect change on the global state of our application.
   ///
-  /// - Throws: An `Error` from the root reducer.
+  /// - Throws: ``Error`` from the root reducer, if any.
   ///
   /// - SeeAlso: The `dispatch(action:)` function serves a similar role as the [`dispatch(action)`](https://redux.js.org/api/store#dispatchaction) function in Redux.
-  @MainActor func dispatch(action: Action) throws
-  
+  @MainActor func dispatch(action: Action) throws(Self.Error)
+
   /// Dispatch a unit of work that could include side effects.
   ///
   /// - Parameter thunk: A unit of work that could include side effects.

--- a/Sources/ImmutableUI/Dispatcher.swift
+++ b/Sources/ImmutableUI/Dispatcher.swift
@@ -75,7 +75,7 @@ import SwiftUI
   }
   
   /// The current store of the environment property.
-  public var wrappedValue: some ImmutableData.Dispatcher<Store.State, Store.Action> {
+  public var wrappedValue: some ImmutableData.Dispatcher<Store.State, Store.Action, Store.Error> {
     self.store
   }
 }

--- a/Tests/ImmutableDataTests/StoreTests.swift
+++ b/Tests/ImmutableDataTests/StoreTests.swift
@@ -43,7 +43,7 @@ extension ReducerTestDouble {
   @Sendable func reduce(
     state: StateTestDouble,
     action: ActionTestDouble
-  ) throws -> StateTestDouble {
+  ) throws(Swift.Error) -> StateTestDouble {
     self.parameterState = state
     self.parameterAction = action
     if let returnError = self.returnError {
@@ -54,15 +54,15 @@ extension ReducerTestDouble {
 }
 
 final fileprivate class ThunkTestDouble : @unchecked Sendable {
-  var parameterDispatcher: Store<StateTestDouble, ActionTestDouble>?
-  var parameterSelector: Store<StateTestDouble, ActionTestDouble>?
+  var parameterDispatcher: Store<StateTestDouble, ActionTestDouble, Swift.Error>?
+  var parameterSelector: Store<StateTestDouble, ActionTestDouble, Swift.Error>?
   var returnError: Error?
 }
 
 extension ThunkTestDouble {
   @Sendable func thunk(
-    dispatcher: Store<StateTestDouble, ActionTestDouble>,
-    selector: Store<StateTestDouble, ActionTestDouble>
+    dispatcher: Store<StateTestDouble, ActionTestDouble, Swift.Error>,
+    selector: Store<StateTestDouble, ActionTestDouble, Swift.Error>
   ) throws {
     self.parameterDispatcher = dispatcher
     self.parameterSelector = selector
@@ -74,8 +74,8 @@ extension ThunkTestDouble {
 
 extension ThunkTestDouble {
   @Sendable func asyncThunk(
-    dispatcher: Store<StateTestDouble, ActionTestDouble>,
-    selector: Store<StateTestDouble, ActionTestDouble>
+    dispatcher: Store<StateTestDouble, ActionTestDouble, Swift.Error>,
+    selector: Store<StateTestDouble, ActionTestDouble, Swift.Error>
   ) async throws {
     self.parameterDispatcher = dispatcher
     self.parameterSelector = selector


### PR DESCRIPTION
I wanted to discuss what you think about this, but figured it's easier with actual code in hand, so here's a PR -- not necessarily meant to merge as-is, but as a starting point.

So with SE-0413 Typed throws we get [an alternative to the (cumbersome) `@rethrows`](https://github.com/swiftlang/swift-evolution/blob/main/proposals/0413-typed-throws.md#an-alternative-to-rethrows) protocol annotation: [set the associated error to `Never`](https://github.com/swiftlang/swift-evolution/blob/main/proposals/0413-typed-throws.md#throwing-any-error-or-never) to express that the function cannot throw.

My motivation to look at this was that even the simple Counter example had to handle a throwing store dispatcher -- even though there were no errors.

With modern Swift and typed throws, we can essentially tell the compiler that this is not "throwing any error, or maybe none at all", but be very precise.

At the cost of a 3rd generic type parameter.

## Counter: non-throwing

I started using this after making the reducer generic in d661685 by implementing a test suite to see whether it compiles and does its job:

```swift
import CounterData
import CounterUI
import ImmutableData
import Foundation
import Testing

@Suite struct CounterUITests {
    @Test func storeDispatch() {
        let store = Store(
            initialState: CounterState(),
            reducer: CounterReducer.reduce
        )
        func value() -> Int {
            return store.select(CounterState.selectValue())
        }

        #expect(value(), 0)

        store.dispatch(action: .didTapDecrementButton)

        #expect(value(), -1)

        store.dispatch(action: .didTapIncrementButton)
        store.dispatch(action: .didTapIncrementButton)

        #expect(value(), 1)
    }
}
```

This led me to tweak CounterUI and friends instead that do a similar job at exercising the API.

In a4c7f1a you see that one preview is now commented-out because you cannot decide that sometimes you want errors, sometimes you don't.

In real-world scenarios, that should (could?) be a feature. But here we see the first limitation of the approach. The `Store` and `Dispatcher` need to declare that errors are expected.

This reflects my motivation and I would call this scenario a 'win'.

## Animals

`AnimalsReducer` does in fact throw an error sometimes. The error needs to be public. You decided to put it inside the reducer, so it's `AnimalsReducer.Error`.

There's no typealias for the concrete dispatcher, so a lot of diff noise where:

```diff+swift
- ImmutableData.Dispatcher<AnimalsState, AnimalsAction>
+ ImmutableData.Dispatcher<AnimalsState, AnimalsAction, AnimalsReducer.Error>
```

Same for the `Store`.

The store double needs to declare `throws(AnimalsReducer.Error)` even though it doesn't for compatibility as a stand-in. This may be a benefit (clarity) or downside 🤷 

## Quakes 

Same story to Animals, but dependencies fetched faster :) 